### PR TITLE
Fix build on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ clean:
 	rm --force generators/*/Dockerfile runtimes/*/Dockerfile
 
 Dockerfile:
-	cpp -o Dockerfile Dockerfile.in -P -nostdinc
+	cpp -P -nostdinc Dockerfile.in Dockerfile
 
 pull:
 	docker pull ${GENERATOR_DOCKER_IMAGE}


### PR DESCRIPTION
Looks like `cpp` on mac is fussy about the arg order, hope it works on Linux as well.﻿
